### PR TITLE
Increase CPU, Memory, and PVC for coordinator

### DIFF
--- a/values-opensearch-coordinator.yaml
+++ b/values-opensearch-coordinator.yaml
@@ -195,8 +195,8 @@ opensearchJavaOpts: "-Xmx512M -Xms512M"
 
 resources:
   requests:
-    cpu: "100m"
-    memory: "2Gi"
+    cpu: "200m"
+    memory: "4Gi"
 
 initResources: {}
 #  limits:
@@ -263,7 +263,7 @@ persistence:
   # storageClass: "-"
   accessModes:
   - ReadWriteOnce
-  size: 10Gi
+  size: 20Gi
   annotations: {}
 
 extraVolumes: []


### PR DESCRIPTION
Due to data not being allowed into the OS cluster due to a "Highwater mark" limitation seeing if a general increase in the resources for the coordinator will address this issue